### PR TITLE
Added support for Regex rules.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,11 @@ be on its own line. Blank lines and lines that start with # (hash) are
 ignored and can be used for spacing and comments.
 
     /2012/09/old-post/ http://www.example.com/2012/09/new-post/
+	
+You can also ro regex mathing and replacment such as some of these examples.  Note that the first mached rule will win.
+
+	/(.*)\.php /$1
+	/(someDir|SomeOtherDir)/? /custom-404
 
 After installing, go to Settings > Redirect Editor to configure.
 
@@ -43,6 +48,9 @@ No, just simple string matching.
 1. That's it, just a textarea.
 
 == Changelog ==
+= 1.4 =
+* Added support for regular expresssios in rules.
+
 = 1.3 =
 * Fix CSS error causing redirect lines to all appear on a single line
 

--- a/redirect-editor.php
+++ b/redirect-editor.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Redirect Editor
-Version: 1.3
+Version: 1.4
 Plugin URI: http://justinsomnia.org/2012/09/redirect-editor-plugin-for-wordpress/
 Description: Centrally edit and manage <code>.htaccess</code>-style 301 redirects. Go to <a href="options-general.php?page=redirect-editor">Settings &gt; Redirect Editor</a> to configure.
 Author: Justin Watt
@@ -114,6 +114,16 @@ class Redirect_Editor_Plugin {
 			if ( array_key_exists( $request_url, $redirects ) ) {
 				wp_redirect( $redirects[$request_url], 301 );
 				exit;
+			}
+			
+			foreach($redirects as $match => $redirect) {
+				if(strpbrk($match, '*$^{}[]')) { // Look for rules with Regex control charectors
+					$match = str_replace('/', '\/', $match);
+					if(preg_match("/$match/", $request_url)) { // See if the url matches the regex rule.
+						wp_redirect ( preg_replace("/$match/", $redirect, $request_url), 301 ); // If so apply the replacment value and redirect.
+						exit;
+					}
+				}
 			}
 		}
 	}

--- a/redirect-editor.php
+++ b/redirect-editor.php
@@ -118,7 +118,7 @@ class Redirect_Editor_Plugin {
 			}
 			
 			foreach($redirects as $match => $redirect) {
-				if(strpbrk($match, '*$^{}[]')) { // Look for rules with Regex control charectors
+				if(strpbrk($match, '*$^{}[]()')) { // Look for rules with Regex control charectors
 					$match = str_replace('/', '\/', $match);
 					if(preg_match("/$match/", $request_url)) { // See if the url matches the regex rule.
 						$prefixSiteUrl = get_site_url() != $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER["HTTP_HOST"] ? get_site_url() : '';

--- a/redirect-editor.php
+++ b/redirect-editor.php
@@ -112,7 +112,8 @@ class Redirect_Editor_Plugin {
 			$redirects = $this->get_setting( 'redirects', array() );
 
 			if ( array_key_exists( $request_url, $redirects ) ) {
-				wp_redirect( $redirects[$request_url], 301 );
+				$prefixSiteUrl = get_site_url() != $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER["HTTP_HOST"] ? get_site_url() : '';
+				wp_redirect( $prefixSiteUrl . $redirects[$request_url], 301 );
 				exit;
 			}
 			
@@ -120,7 +121,8 @@ class Redirect_Editor_Plugin {
 				if(strpbrk($match, '*$^{}[]')) { // Look for rules with Regex control charectors
 					$match = str_replace('/', '\/', $match);
 					if(preg_match("/$match/", $request_url)) { // See if the url matches the regex rule.
-						wp_redirect ( preg_replace("/$match/", $redirect, $request_url), 301 ); // If so apply the replacment value and redirect.
+						$prefixSiteUrl = get_site_url() != $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER["HTTP_HOST"] ? get_site_url() : '';
+						wp_redirect ( $prefixSiteUrl . preg_replace("/$match/", $redirect, $request_url), 301 ); // If so apply the replacment value and redirect.
 						exit;
 					}
 				}


### PR DESCRIPTION
This is a straightforward approach at add regular expression support.  There is no inate markup offlag on the users end to use regex.  Rather they just write rules as normal but can include regular expressions if they wish.

When the redirects are processed, first a matching static rule is used if found.  If not then the list is search for lines with regular expression control characters , $^[]{}()*, and if found then the rule is tested.  If it matches the URL then it is applied and redirected.  Ie only the first rule will win.